### PR TITLE
Support coroutine for rpc request

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,31 @@ session.bind_method("add", [&session, executor](json::object obj) {
 });
 ```
 
-上面处理 `RPC` 请求示例中，我们可以在 `bind_method` 中的回调函数中处理 `RPC` 请求，也可以创建一个异步协程来处理 `RPC` 请求，这取决于我们的需求。
+上面处理 `RPC` 请求示例中，我们可以在 `bind_method` 中的回调函数中处理 `RPC` 请求，也可以创建一个异步协程来处理 `RPC` 请求，这取决于我们的需求，下面是使用 `bind_coroutine` 异步协程处理 `RPC` 请求的示例：
+
+``` c++
+// 绑定 mul 方法
+session.bind_coroutine("mul",
+    [&session, executor](json::object obj) mutable -> net::awaitable<void> {
+        // 处理 mul 方法调用, 这里只是作为示例打印输出请求 JSON 对象
+        std::cout << "[mul] method called with obj: " << json::serialize(obj) << "\n";
+
+        // 模拟一些异步操作, 例如等待 3 秒钟
+        co_await net::steady_timer(session.get_executor(), std::chrono::seconds(3)).async_wait(net::use_awaitable);
+
+        auto params = obj["params"].as_object();
+        auto a = params["a"].as_int64();
+        auto b = params["b"].as_int64();
+
+        json::object response = {
+            {"val", a * b},
+        };
+
+        // 回复请求, 使用 jsonrpc_id(obj) 获取请求的 ID 使客户端能够匹配响应
+        session.reply(response, jsonrpc::jsonrpc_id(obj));
+        co_return;
+    });
+```
 
 ## 设计优势
 

--- a/example/client/client.cpp
+++ b/example/client/client.cpp
@@ -65,12 +65,16 @@ net::awaitable<void> client_session(std::string host, std::string port)
         }
     );
 
-    json::object add_req{
+    json::object compute_req{
         {"a", 10}, {"b", 3}
     };
     // add RPC 调用, 通过C++20协程的方式
-    auto result = co_await session.async_call("add", add_req, net::use_awaitable);
+    auto result = co_await session.async_call("add", compute_req, net::use_awaitable);
     std::cout << "[add] result: " << json::serialize(result) << std::endl;
+
+    // mul RPC 调用, 通过C++20协程的方式
+    result = co_await session.async_call("mul", compute_req, net::use_awaitable);
+    std::cout << "[mul] result: " << json::serialize(result) << std::endl;
 }
 
 int main(int argc, char* argv[]) {

--- a/example/server/server.cpp
+++ b/example/server/server.cpp
@@ -75,6 +75,27 @@ net::awaitable<void> do_jsonrpc(session_type session)
 
     auto executor = co_await net::this_coro::executor;
 
+    session.bind_coroutine("mul",
+        [&session, executor](json::object obj) mutable -> net::awaitable<void> {
+            // 处理 mul 方法调用, 这里只是作为示例打印输出请求 JSON 对象
+            std::cout << "[mul] method called with obj: " << json::serialize(obj) << "\n";
+
+            // 模拟一些异步操作, 例如等待 3 秒钟
+            co_await net::steady_timer(session.get_executor(), std::chrono::seconds(3)).async_wait(net::use_awaitable);
+
+            auto params = obj["params"].as_object();
+            auto a = params["a"].as_int64();
+            auto b = params["b"].as_int64();
+
+            json::object response = {
+                {"val", a * b},
+            };
+
+            // 回复请求, 使用 jsonrpc_id(obj) 获取请求的 ID 使客户端能够匹配响应
+            session.reply(response, jsonrpc::jsonrpc_id(obj));
+            co_return;
+        });
+
     // 绑定 add 方法
     session.bind_method("add", [&session, executor](json::object obj) {
         // 处理 add 方法调用, 这里只是作为示例打印输出请求 JSON 对象

--- a/include/tinyrpc/jsonrpc.hpp
+++ b/include/tinyrpc/jsonrpc.hpp
@@ -47,6 +47,8 @@ namespace jsonrpc
   namespace net = boost::asio;
   namespace json = boost::json;
 
+  using coroutine_type = std::function<net::awaitable<void>(json::object)>;
+
   namespace detail
   {
     template <typename T, typename = void>
@@ -204,6 +206,7 @@ namespace jsonrpc
       , error_cb_(std::move(rhs.error_cb_))
       , notify_cb_(std::move(rhs.notify_cb_))
       , remote_methods_(std::move(rhs.remote_methods_))
+      , remote_coroutines_(std::move(rhs.remote_coroutines_))
       , write_msgs_(std::move(rhs.write_msgs_))
     {
       if (rhs.running_)
@@ -421,6 +424,31 @@ namespace jsonrpc
       }
 
       remote_methods_[std::string(method_name)] = std::move(handler);
+    }
+
+    // 绑定一个 JSON-RPC 方法调用的协程函数, 当接收到对应的方法调用时会调用该函数.
+    // 方法名是一个字符串, 代表远程方法的名称, handler 是一个协程函数,
+    // 接受一个 json::object 作为参数, 代表接收到的请求消息.
+    template<typename CoroHandler>
+    void bind_coroutine(
+      std::string_view method_name,
+      CoroHandler&& handler)
+    {
+      if (method_name.empty())
+      {
+        BOOST_ASSERT(false && "method name or coroutine is invalid");
+        return;
+      }
+
+      auto coroutine_handler = [
+        handler = std::forward<CoroHandler>(handler)]
+        (json::object obj) mutable -> net::awaitable<void>
+        {
+            // 执行用户协程
+            co_await handler(std::move(obj));
+        };
+
+      remote_coroutines_[std::string(method_name)] = std::move(handler);
     }
 
     // 设置请求回调函数, 当接收到请求消息时会调用该函数.
@@ -697,22 +725,32 @@ namespace jsonrpc
 
     net::awaitable<void> handle_method(json::object obj, std::string_view method_name)
     {
-      // 检查是否有对应的远程方法
-      auto it = remote_methods_.find(std::string(method_name));
-      if (it != remote_methods_.end())
       {
-        // 找到对应的远程方法，调用它
-        it->second(std::move(obj));
+        // 检查协程中是否存在
+        auto it = remote_coroutines_.find(std::string(method_name));
+        if (it != remote_coroutines_.end())
+        {
+          co_await it->second(std::move(obj));
+        }
       }
-      else if (method_cb_)
       {
-        // 如果没有找到对应的远程方法，调用默认的 method 回调函数
-        method_cb_(std::move(obj));
-      }
-      else
-      {
-        // 没有设置 method 回调函数，忽略该消息
-        BOOST_ASSERT(false && "no method callback set");
+        // 检查是否有对应的远程方法
+        auto it = remote_methods_.find(std::string(method_name));
+        if (it != remote_methods_.end())
+        {
+          // 找到对应的远程方法，调用它
+          it->second(std::move(obj));
+        }
+        else if (method_cb_)
+        {
+          // 如果没有找到对应的远程方法，调用默认的 method 回调函数
+          method_cb_(std::move(obj));
+        }
+        else
+        {
+          // 没有设置 method 回调函数，忽略该消息
+          BOOST_ASSERT(false && "no method callback set");
+        }
       }
 
       co_return;
@@ -792,6 +830,8 @@ namespace jsonrpc
     // 注册的 RPC 调用方法.
     std::unordered_map<std::string,
       std::function<void(json::object)>> remote_methods_;
+    std::unordered_map<std::string,
+      coroutine_type> remote_coroutines_;
 
     // 保护调用操作的互斥锁.
     std::mutex call_op_mutex_;


### PR DESCRIPTION
server 端处理 rpc 请求支持 coroutine，示例如下：

``` c++
// 绑定 mul 方法
session.bind_coroutine("mul",
    [&session, executor](json::object obj) mutable -> net::awaitable<void> {
        // 处理 mul 方法调用, 这里只是作为示例打印输出请求 JSON 对象
        std::cout << "[mul] method called with obj: " << json::serialize(obj) << "\n";

        // 模拟一些异步操作, 例如等待 3 秒钟
        co_await net::steady_timer(session.get_executor(), std::chrono::seconds(3)).async_wait(net::use_awaitable);

        auto params = obj["params"].as_object();
        auto a = params["a"].as_int64();
        auto b = params["b"].as_int64();

        json::object response = {
            {"val", a * b},
        };

        // 回复请求, 使用 jsonrpc_id(obj) 获取请求的 ID 使客户端能够匹配响应
        session.reply(response, jsonrpc::jsonrpc_id(obj));
        co_return;
    });
```
