### PR TITLE
改善 RPC 消息处理方法，支持通过返回 message 自动回复请求，同时也支持手工回复请求

### DIFF
--- a/example/client/client.cpp
+++ b/example/client/client.cpp
@@ -55,13 +55,13 @@ net::awaitable<void> client_session(std::string host, std::string port)
         {"a", 42}, {"b", 5}
     };
 
-    // subtract RPC 调用, 通过异步回调的方式
-    session.async_call("subtract", subtract_req,
+    // sub RPC 调用, 通过异步回调的方式
+    session.async_call("sub", subtract_req,
         [&](boost::system::error_code ec, json::object result) {
             if (!ec)
-                std::cout << "[subtract] result: " << json::serialize(result) << std::endl;
+                std::cout << "[sub] result: " << json::serialize(result) << std::endl;
             else
-                std::cerr << "subtract error: " << ec.message() << std::endl;
+                std::cerr << "sub error: " << ec.message() << std::endl;
         }
     );
 
@@ -75,6 +75,10 @@ net::awaitable<void> client_session(std::string host, std::string port)
     // mul RPC 调用, 通过C++20协程的方式
     result = co_await session.async_call("mul", compute_req, net::use_awaitable);
     std::cout << "[mul] result: " << json::serialize(result) << std::endl;
+
+    // div RPC 调用, 通过C++20协程的方式
+    result = co_await session.async_call("div", compute_req, net::use_awaitable);
+    std::cout << "[div] result: " << json::serialize(result) << std::endl;
 }
 
 int main(int argc, char* argv[]) {

--- a/example/server/server.cpp
+++ b/example/server/server.cpp
@@ -52,10 +52,10 @@ net::awaitable<void> do_jsonrpc(session_type session)
     });
 
 
-    // 绑定 subtract 方法
-    session.bind_method("subtract", [&session](json::object obj) {
-        // 处理 subtract 方法调用, 这里只是作为示例打印输出请求 JSON 对象
-        std::cout << "[subtract] method called with obj: " << json::serialize(obj) << "\n";
+    // 绑定 sub 方法
+    session.bind_method("sub", [&session](json::object obj) -> json::object {
+        // 处理 sub 方法调用, 这里只是作为示例打印输出请求 JSON 对象
+        std::cout << "[sub] method called with obj: " << json::serialize(obj) << "\n";
 
         // 回复请求, 回复的内容是一个 JSON 对象, 作为 JSONRPC 协议的 result 部分
         // 我们不需要关心 JSONRPC 协议的其它字段
@@ -65,36 +65,14 @@ net::awaitable<void> do_jsonrpc(session_type session)
         auto b = params["b"].as_int64();
 
         json::object response = {
-            {"val", a + b},
+            {"val", a - b},
         };
 
-        // 回复请求, 使用 jsonrpc_id(obj) 获取请求的 ID 使客户端能够匹配响应
-        session.reply(response, jsonrpc::jsonrpc_id(obj));
+        // 通过 return 回复请求.
+        return response;
     });
 
-
     auto executor = co_await net::this_coro::executor;
-
-    session.bind_coroutine("mul",
-        [&session](json::object obj) mutable -> net::awaitable<void> {
-            // 处理 mul 方法调用, 这里只是作为示例打印输出请求 JSON 对象
-            std::cout << "[mul] method called with obj: " << json::serialize(obj) << "\n";
-
-            // 模拟一些异步操作, 例如等待 3 秒钟
-            co_await net::steady_timer(session.get_executor(), std::chrono::seconds(3)).async_wait(net::use_awaitable);
-
-            auto params = obj["params"].as_object();
-            auto a = params["a"].as_int64();
-            auto b = params["b"].as_int64();
-
-            json::object response = {
-                {"val", a * b},
-            };
-
-            // 回复请求, 使用 jsonrpc_id(obj) 获取请求的 ID 使客户端能够匹配响应
-            session.reply(response, jsonrpc::jsonrpc_id(obj));
-            co_return;
-        });
 
     // 绑定 add 方法
     session.bind_method("add", [&session, executor](json::object obj) {
@@ -116,12 +94,52 @@ net::awaitable<void> do_jsonrpc(session_type session)
                 {"val", a + b},
             };
 
-            // 回复请求, 使用 jsonrpc_id(obj) 获取请求的 ID 使客户端能够匹配响应
+            // 手工回复请求, 使用 jsonrpc_id(obj) 获取请求的 ID 使客户端能够匹配响应
             session.reply(response, jsonrpc::jsonrpc_id(obj));
-
             co_return;
         }, net::detached);
     });
+
+    session.bind_method("mul",
+        [&session](json::object obj) mutable -> net::awaitable<void> {
+            // 处理 mul 方法调用, 这里只是作为示例打印输出请求 JSON 对象
+            std::cout << "[mul] method called with obj: " << json::serialize(obj) << "\n";
+
+            // 模拟一些异步操作, 例如等待 3 秒钟
+            co_await net::steady_timer(session.get_executor(), std::chrono::seconds(3)).async_wait(net::use_awaitable);
+
+            auto params = obj["params"].as_object();
+            auto a = params["a"].as_int64();
+            auto b = params["b"].as_int64();
+
+            json::object response = {
+                {"val", a * b},
+            };
+
+            // 手工回复请求, 使用 jsonrpc_id(obj) 获取请求的 ID 使客户端能够匹配响应
+            session.reply(response, jsonrpc::jsonrpc_id(obj));
+            co_return;
+        });
+
+    session.bind_method("div",
+        [&session](json::object obj) mutable -> net::awaitable<json::object> {
+            // 处理 div 方法调用, 这里只是作为示例打印输出请求 JSON 对象
+            std::cout << "[div] method called with obj: " << json::serialize(obj) << "\n";
+
+            // 模拟一些异步操作, 例如等待 3 秒钟
+            co_await net::steady_timer(session.get_executor(), std::chrono::seconds(3)).async_wait(net::use_awaitable);
+
+            auto params = obj["params"].as_object();
+            auto a = params["a"].as_int64();
+            auto b = params["b"].as_int64();
+
+            json::object response = {
+                {"val", a / b},
+            };
+
+            // 通过 co_return 回复请求.
+            co_return response;
+        });
 
     //////////////////////////////////////////////////////////////////////////
     // 处理 WebSocket 消息的循环

--- a/include/tinyrpc/jsonrpc.hpp
+++ b/include/tinyrpc/jsonrpc.hpp
@@ -11,7 +11,6 @@
 #ifndef INCLUDE__2023_10_18__JSONRPC_HPP
 #define INCLUDE__2023_10_18__JSONRPC_HPP
 
-#include <atomic>
 #include <functional>
 #include <memory>
 #include <utility>
@@ -67,6 +66,107 @@ namespace jsonrpc
         : std::is_same<void, decltype(std::declval<T>().close())>
     {
     };
+
+    // 函数特征模板，用于获取函数的参数类型和返回类型, 支持函数指针、函数对象和 lambda 表达式
+    // 参考来源: boost/leaf/detail/function_traits.hpp
+    template<class... T> struct mp_list
+    {
+    };
+
+    template<class L> struct mp_pop_front_impl
+    {
+      // An error "no type named 'type'" here means that the argument to mp_pop_front
+      // is either not a list, or is an empty list
+    };
+
+    template<template<class...> class L, class T1, class... T> struct mp_pop_front_impl<L<T1, T...>>
+    {
+        using type = L<T...>;
+    };
+
+    template<class L> using mp_pop_front = typename mp_pop_front_impl<L>::type;
+    template<class L> using mp_rest = mp_pop_front<L>;
+
+
+    template <class T> struct remove_noexcept { using type = T; };
+    template <class R, class... A>  struct remove_noexcept<R(*)(A...) noexcept> { using type = R(*)(A...); };
+    template <class C, class R, class... A>  struct remove_noexcept<R(C::*)(A...) noexcept> { using type = R(C::*)(A...); };
+    template <class C, class R, class... A>  struct remove_noexcept<R(C::*)(A...) const noexcept> { using type = R(C::*)(A...) const; };
+
+    template<class...>
+    struct gcc49_workaround //Thanks Glen Fernandes
+    {
+        using type = void;
+    };
+
+    template<class... T>
+    using void_t = typename gcc49_workaround<T...>::type;
+
+    template<class F,class V=void>
+    struct function_traits_impl
+    {
+        constexpr static int arity = -1;
+    };
+
+    template<class F>
+    struct function_traits_impl<F, void_t<decltype(&F::operator())>>
+    {
+    private:
+
+        using tr = function_traits_impl<typename remove_noexcept<decltype(&F::operator())>::type>;
+
+    public:
+
+        using return_type = typename tr::return_type;
+        static constexpr int arity = tr::arity - 1;
+
+        using mp_args = mp_rest<typename tr::mp_args>;
+
+        template <int I>
+        struct arg:
+            tr::template arg<I+1>
+        {
+        };
+    };
+
+    template<class R, class... A>
+    struct function_traits_impl<R(A...)>
+    {
+        using return_type = R;
+        static constexpr int arity = sizeof...(A);
+
+        using mp_args = mp_list<A...>;
+
+        template <int I>
+        struct arg
+        {
+            static_assert(I < arity, "I out of range");
+            using type = typename std::tuple_element<I,std::tuple<A...>>::type;
+        };
+    };
+
+    template<class F> struct function_traits_impl<F&> : function_traits_impl<F> { };
+    template<class F> struct function_traits_impl<F&&> : function_traits_impl<F> { };
+    template<class R, class... A> struct function_traits_impl<R(*)(A...)> : function_traits_impl<R(A...)> { };
+    template<class R, class... A> struct function_traits_impl<R(* &)(A...)> : function_traits_impl<R(A...)> { };
+    template<class R, class... A> struct function_traits_impl<R(* const &)(A...)> : function_traits_impl<R(A...)> { };
+    template<class C, class R, class... A> struct function_traits_impl<R(C::*)(A...)> : function_traits_impl<R(C&,A...)> { };
+    template<class C, class R, class... A> struct function_traits_impl<R(C::*)(A...) const> : function_traits_impl<R(C const &,A...)> { };
+    template<class C, class R> struct function_traits_impl<R(C::*)> : function_traits_impl<R(C&)> { };
+
+    template <class F>
+    struct function_traits: function_traits_impl<typename remove_noexcept<F>::type>
+    {
+    };
+
+    template <class F>
+    using fn_return_type = typename function_traits<F>::return_type;
+
+    template <class F, int I>
+    using fn_arg_type = typename function_traits<F>::template arg<I>::type;
+
+    template <class F>
+    using fn_mp_args = typename function_traits<F>::mp_args;
 
     // RPC 操作的抽象基类
     class rpc_operation
@@ -206,7 +306,6 @@ namespace jsonrpc
       , error_cb_(std::move(rhs.error_cb_))
       , notify_cb_(std::move(rhs.notify_cb_))
       , remote_methods_(std::move(rhs.remote_methods_))
-      , remote_coroutines_(std::move(rhs.remote_coroutines_))
       , write_msgs_(std::move(rhs.write_msgs_))
     {
       if (rhs.running_)
@@ -410,29 +509,11 @@ namespace jsonrpc
       write_message(std::move(context));
     }
 
-    // 当接收到对应的 JSON-RPC 方法调用时会调用该函数, 方法名是一个
-    // 字符串, 代表远程方法的名称, handler 是一个函数对象,
-    // 接受一个 json::object 作为参数, 代表接收到的请求消息.
-    void bind_method(
-      std::string_view method_name,
-      std::function<void(json::object)> handler)
-    {
-      if (method_name.empty() || !handler)
-      {
-        BOOST_ASSERT(false && "method name or handler is invalid");
-        return;
-      }
-
-      remote_methods_[std::string(method_name)] = std::move(handler);
-    }
-
     // 绑定一个 JSON-RPC 方法调用的协程函数, 当接收到对应的方法调用时会调用该函数.
-    // 方法名是一个字符串, 代表远程方法的名称, handler 是一个协程函数,
+    // 方法名是一个字符串, 代表远程方法的名称, handler 是一个协程函数或普通函数,
     // 接受一个 json::object 作为参数, 代表接收到的请求消息.
-    template<typename CoroHandler>
-    void bind_coroutine(
-      std::string_view method_name,
-      CoroHandler&& handler)
+    template<typename Handler>
+    void bind_method(std::string_view method_name, Handler&& handler)
     {
       if (method_name.empty())
       {
@@ -441,14 +522,34 @@ namespace jsonrpc
       }
 
       auto coroutine_handler = [
-        handler = std::forward<CoroHandler>(handler)]
+        this, handler = std::forward<Handler>(handler)]
         (json::object obj) mutable -> net::awaitable<void>
         {
-            // 执行用户协程
+          using ReturnType = detail::fn_return_type<Handler>;
+
+          if constexpr (std::same_as<ReturnType, net::awaitable<void>>)
+          {
             co_await handler(std::move(obj));
+          }
+          else if constexpr (std::is_same_v<ReturnType, net::awaitable<json::object>>)
+          {
+            auto id = jsonrpc::jsonrpc_id(obj);
+            auto response = co_await handler(std::move(obj));
+            reply(response, id);
+          }
+          else if constexpr (std::is_same_v<ReturnType, json::object>)
+          {
+            auto id = jsonrpc::jsonrpc_id(obj);
+            auto response = handler(std::move(obj));
+            reply(response, id);
+          }
+          else if constexpr (std::is_same_v<ReturnType, void>)
+          {
+            handler(std::move(obj));
+          }
         };
 
-      remote_coroutines_[std::string(method_name)] = std::move(handler);
+      remote_methods_[std::string(method_name)] = std::move(coroutine_handler);
     }
 
     // 设置请求回调函数, 当接收到请求消息时会调用该函数.
@@ -725,32 +826,20 @@ namespace jsonrpc
 
     net::awaitable<void> handle_method(json::object obj, std::string_view method_name)
     {
+      // 检查协程中是否存在
+      auto it = remote_methods_.find(std::string(method_name));
+      if (it != remote_methods_.end())
       {
-        // 检查协程中是否存在
-        auto it = remote_coroutines_.find(std::string(method_name));
-        if (it != remote_coroutines_.end())
-        {
-          co_await it->second(std::move(obj));
-        }
+        co_await it->second(std::move(obj));
       }
+      else if (method_cb_)
       {
-        // 检查是否有对应的远程方法
-        auto it = remote_methods_.find(std::string(method_name));
-        if (it != remote_methods_.end())
-        {
-          // 找到对应的远程方法，调用它
-          it->second(std::move(obj));
-        }
-        else if (method_cb_)
-        {
-          // 如果没有找到对应的远程方法，调用默认的 method 回调函数
-          method_cb_(std::move(obj));
-        }
-        else
-        {
-          // 没有设置 method 回调函数，忽略该消息
-          BOOST_ASSERT(false && "no method callback set");
-        }
+        method_cb_(std::move(obj));
+      }
+      else
+      {
+        // 没有设置 method 回调函数，忽略该消息
+        BOOST_ASSERT(false && "no method callback set");
       }
 
       co_return;
@@ -828,10 +917,7 @@ namespace jsonrpc
     std::function<std::string(std::string_view)> data_cb_;
 
     // 注册的 RPC 调用方法.
-    std::unordered_map<std::string,
-      std::function<void(json::object)>> remote_methods_;
-    std::unordered_map<std::string,
-      coroutine_type> remote_coroutines_;
+    std::unordered_map<std::string, coroutine_type> remote_methods_;
 
     // 保护调用操作的互斥锁.
     std::mutex call_op_mutex_;


### PR DESCRIPTION
通过 rpc 的消息处理函数返回值来判定是否自动回复，若无返回值则需要手工调用 `reply` 回复客户端的 rpc 请求, 若返回 json.object 则表示由库调用 `reply` 回复 rpc 请求, 协程和非协程处理函数采用相同处理逻辑.